### PR TITLE
Add safety timeout

### DIFF
--- a/cmd/2b-server/main.go
+++ b/cmd/2b-server/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/DanNixon/go-2b/pkg/powerbox"
 	"github.com/DanNixon/go-2b/pkg/types"
@@ -87,14 +88,20 @@ func powerboxKill(w http.ResponseWriter, r *http.Request) {
 func main() {
 	port := flag.String("port", "", "Serial port powerbox is connected to")
 	address := flag.String("address", "127.0.0.1:8080", "Address to listen on")
+	timeoutStr := flag.String("timeout", "1m", "Duration with no set commands after which output is killed")
 	flag.Parse()
 
 	if *port == "" {
 		log.Fatal("Serial port must be specified")
 	}
 
-	var err error
-	pb, err = powerbox.NewSerialPowerbox(*port)
+	timeout, err := time.ParseDuration(*timeoutStr)
+	if err != nil {
+		log.Fatalf("Cannot parse timeout duration: %v", err)
+	}
+	log.Printf("\"No command\" timeout duration is %v", timeout)
+
+	pb, err = powerbox.NewSerialPowerbox(*port, timeout)
 	if err != nil {
 		log.Fatalf("Failed to open serial port: %v", err)
 	}

--- a/pkg/powerbox/powerbox.go
+++ b/pkg/powerbox/powerbox.go
@@ -1,10 +1,41 @@
 package powerbox
 
-import "github.com/DanNixon/go-2b/pkg/types"
+import (
+	"log"
+	"time"
+
+	"github.com/DanNixon/go-2b/pkg/types"
+)
 
 type Powerbox interface {
 	Reset() (types.Status, error)
 	Kill() (types.Status, error)
 	Set(s types.Settings) (types.Status, error)
 	Get() (types.Status, error)
+}
+
+type PowerboxTimeout struct {
+	Timeout  time.Duration
+	Timer    *time.Timer
+	KillFunc func() (types.Status, error)
+}
+
+func NewPowerboxTimeout(timeout time.Duration, f func() (types.Status, error)) *PowerboxTimeout {
+	t := PowerboxTimeout{
+		Timeout:  timeout,
+		KillFunc: f,
+	}
+	t.Timer = time.AfterFunc(timeout, t.onTimeout)
+	return &t
+}
+
+func (t *PowerboxTimeout) Ping() {
+	t.Timer.Stop()
+	t.Timer.Reset(t.Timeout)
+}
+
+func (t *PowerboxTimeout) onTimeout() {
+	t.KillFunc()
+	log.Printf("Timeout elapsed, powerbox output killed")
+	t.Timer.Reset(t.Timeout)
 }


### PR DESCRIPTION
Adds a timeout that will disable powerbox output if no "set" command was received in a given duration.

Designed to protect against failures in networks and upstream applications which would prevent any command to alter or disable powerbox output from reaching the host running `2b-server`.