### PR TITLE
Fix status reporting for single parameter modes

### DIFF
--- a/pkg/powerbox/serial_powerbox.go
+++ b/pkg/powerbox/serial_powerbox.go
@@ -80,6 +80,16 @@ func (p *SerialPowerbox) Set(s types.Settings) (types.Status, error) {
 		}
 	}
 
+	// This gets around an issue when using modes with a single parameter where
+	// the powerbox sometimes reports the requested value of D and other times
+	// the "actual" value (where the actual value is equal to the value of C).
+	// I *think* this is a firmware issue, as I can't see any communication
+	// issues in other modes.
+	parameterCount, err := st.Settings.Mode.ParameterCount()
+	if parameterCount == 1 {
+		s.Parameters.D = st.Settings.Parameters.D
+	}
+
 	if st.Settings != s {
 		return st, errors.New("Powerbox reports different settings from requested after update")
 	}

--- a/pkg/types/modes.go
+++ b/pkg/types/modes.go
@@ -33,3 +33,17 @@ func (m Mode) Validate() error {
 	}
 	return errors.New("Mode not valid")
 }
+
+var singleParameterModes = []Mode{ModeContinuous, ModeThrob, ModeThrust}
+
+func (m Mode) ParameterCount() (int, error) {
+	err := m.Validate()
+	n := 2
+	for _, sp := range singleParameterModes {
+		if m == sp {
+			n = 1
+			break
+		}
+	}
+	return n, err
+}

--- a/pkg/types/modes_test.go
+++ b/pkg/types/modes_test.go
@@ -19,3 +19,17 @@ func TestModeValidateInvalid(t *testing.T) {
 	err := mode.Validate()
 	assert.NotNil(t, err)
 }
+
+func TestModeParameterCount1(t *testing.T) {
+	mode := types.Mode("continuous")
+	paramCount, err := mode.ParameterCount()
+	assert.Nil(t, err)
+	assert.Equal(t, paramCount, 1)
+}
+
+func TestModeParameterCount2(t *testing.T) {
+	mode := types.Mode("pulse")
+	paramCount, err := mode.ParameterCount()
+	assert.Nil(t, err)
+	assert.Equal(t, paramCount, 2)
+}


### PR DESCRIPTION
Sometimes a `set` command can return as failed when using a mode with a single parameter, sporadically the value of D will be equal to the value of C and the rest of the time the requested value.

When D = C is returned this causes the check that the current status is the requested settings to fail.
This patch checks if the mode only has a single parameter and ignores the returned value of D (as it would not be used in any case).